### PR TITLE
Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Currently, Tor relay bandwidths are [estimated by active measurements](https://b
 
 Other tor relay maps:
 ------
+[Tor Exit Nodes Analyzed and Mapped](https://spyse.com/blog/cybersecurity-research/tor-exit-nodes-mapped)
+
 [Vidalia Network Map](https://tails.boum.org/doc/anonymous_internet/vidalia/index.en.html#index1h1)
 
 [Vidalia Network Map using Marble 3D Globe](https://blog.torproject.org/blog/technology-preview-marble-and-vidalia020)


### PR DESCRIPTION
Added one more source with statistics on exit nodes.

Also, seems like those links are not valid:
1. https://tails.boum.org/doc/anonymous_internet/vidalia/index.en.html#index1h1
2. http://moblog.wiredwings.com/archives/20101213/visualization-tor-nodes-on-google-maps-and-google-earth.html
3. http://bitly.com/tor_map
4. http://blockchain.info/nodes-globe